### PR TITLE
Fix annotation location to match new spec

### DIFF
--- a/manifests/apple.yaml
+++ b/manifests/apple.yaml
@@ -3,15 +3,15 @@ kind: Deployment
 metadata:
   name: apple
   namespace: produce-aisle
-  annotations:
-    greymatter.io/inject-sidecar-to: "8080"
-    greymatter.io/configure-sidecar: "true"
 spec:
   selector:
     matchLabels:
       app: apple
   template:
     metadata:
+      annotations:
+        greymatter.io/inject-sidecar-to: "8080"
+        greymatter.io/configure-sidecar: "true"
       labels:
         app: apple
     spec:

--- a/manifests/banana.yaml
+++ b/manifests/banana.yaml
@@ -4,15 +4,15 @@ kind: Deployment
 metadata:
   name: banana
   namespace: produce-aisle
-  annotations:
-    greymatter.io/inject-sidecar-to: "8080"
-    greymatter.io/configure-sidecar: "true"
 spec:
   selector:
     matchLabels:
       app: banana
   template:
     metadata:
+      annotations:
+        greymatter.io/inject-sidecar-to: "8080"
+        greymatter.io/configure-sidecar: "true"
       labels:
         app: banana
     spec:

--- a/manifests/lettuce.yaml
+++ b/manifests/lettuce.yaml
@@ -3,15 +3,15 @@ kind: Deployment
 metadata:
   name: lettuce
   namespace: produce-aisle
-  annotations:
-    greymatter.io/inject-sidecar-to: "8080"
-    greymatter.io/configure-sidecar: "true"
 spec:
   selector:
     matchLabels:
       app: lettuce
   template:
     metadata:
+      annotations:
+        greymatter.io/inject-sidecar-to: "8080"
+        greymatter.io/configure-sidecar: "true"
       labels:
         app: lettuce
     spec:

--- a/manifests/tomato.yaml
+++ b/manifests/tomato.yaml
@@ -4,15 +4,15 @@ kind: Deployment
 metadata:
   name: tomato
   namespace: produce-aisle
-  annotations:
-    greymatter.io/inject-sidecar-to: "8080"
-    greymatter.io/configure-sidecar: "true"
 spec:
   selector:
     matchLabels:
       app: tomato
   template:
     metadata:
+      annotations:
+        greymatter.io/inject-sidecar-to: "8080"
+        greymatter.io/configure-sidecar: "true"
       labels:
         app: tomato
     spec:


### PR DESCRIPTION
Recent changes to the operator included a change to where it expects the k8s annotations to exist. This PR fixes the stale manifest structure so that the operator injects sidecar for the produce aisle services again. 